### PR TITLE
Update fetch config repo accept header based on server version

### DIFF
--- a/util/gocd.js
+++ b/util/gocd.js
@@ -1,12 +1,36 @@
 const fs = require('fs');
 const rp = require('request-promise');
 
+
+function fetchVersion(serverUrl, accessToken) {
+  const options = {
+    url: `${serverUrl}/api/version`,
+    headers: {
+      'Authorization': `bearer ${accessToken}`,
+      'Accept':        'application/vnd.go.cd.v1+json'
+    }
+  }
+  return rp(options).then(function (json) {
+    const res = JSON.parse(json);
+    return res.version
+  }
+}
+
+
 function fetch(serverUrl, accessToken, id) {
+
+  const serverVersion = fetchVersion(serverUrl, accessToken)
+  
+  var acceptVersion = "v2"
+  if (serverVersion >= "20.8.0") {
+      acceptVersion = "v4"
+  }
+  
   const options = {
     url:     `${serverUrl}/api/admin/config_repos/${id}`,
     headers: {
       'Authorization': `bearer ${accessToken}`,
-      'Accept':        'application/vnd.go.cd.v2+json'
+      'Accept':        `application/vnd.go.cd.${acceptVersion}+json`
     }
   };
 


### PR DESCRIPTION
This action fails if the server version is > 20.8.0 because the get config repo actions has been 'Updated to version v4 since v20.8.0.' 

The changes proposed change the Accept header to be compatible with newer versions and also keep backwards compability.
